### PR TITLE
docs: fix outdated pure-perl-make install commands

### DIFF
--- a/README
+++ b/README
@@ -9,9 +9,9 @@ Requires perl5.005 or later as it uses some of new regular expression features.
 To install 
 
 perl Makefile.PL
-perl -I. pure-perl-make 
-perl -Mblib pure-perl-make test 
-perl -Mblib pure-perl-make install 
+perl -Ilib ./scripts/pure-perl-make
+perl -Mblib ./scripts/pure-perl-make test
+perl -Mblib ./scripts/pure-perl-make install
 
 No other make required!
 


### PR DESCRIPTION
## Summary
This updates the README install commands so they match the current repository layout (`scripts/pure-perl-make`).

## Before
The documented commands call `pure-perl-make` from the repository root, which fails with:
`Can't open perl script "pure-perl-make": No such file or directory`

## After
README now uses `./scripts/pure-perl-make` and `-Ilib`, which run successfully.

## Verification
- `perl Makefile.PL`
- `perl -I. pure-perl-make` (fails as documented above)
- `perl -Ilib ./scripts/pure-perl-make` (succeeds)

Residual uncertainty: I did not run full install (`... install`) to avoid mutating system Perl in this environment.
